### PR TITLE
Use `properties-order` instead of `declaration-block-properties-specified-order`

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = {
     'stylelint-order'
   ],
   rules : {
-    'order/declaration-block-properties-specified-order': [
+    'order/properties-order': [
       'position',
       'z-index',
       'top',


### PR DESCRIPTION
`declaration-block-properties-specified-order` is deprecated. Therefore, instead use `properties-order`.

refs:
- https://github.com/hudochenkov/stylelint-order/releases/tag/0.4.0